### PR TITLE
PP-1447 Fix for pull requests REBASED into master instead of MERGED

### DIFF
--- a/public/src/pages/releases-pipeline-page/js/github-data-service.js
+++ b/public/src/pages/releases-pipeline-page/js/github-data-service.js
@@ -154,6 +154,15 @@ define(
             var extendWithPullRequestDetails = tag => {
               var match = tag.commit.message.match(new RegExp('^Merge pull request \#(.*) from'));
 
+              if (!match) return _.extend({}, tag, {
+                pullRequest: {
+                  userName: "N/A",
+                  userAvatar: "",
+                  url: "",
+                  body: "N/A"
+                }
+              });
+
               return getApiFor(tag.project.name).pulls(match[1]).fetch().then(pullRequestData => {
                 return _.extend({}, tag, {
                   pullRequest: {


### PR DESCRIPTION
Github's new feature allowing to REBASE pull requests into master instead of MERGE
has the side effect to not create a merge commit which pay-admin-dashboad
relies upon. When no merge commit is found, simply ignore and show N/A
for all the information that cannot be pulled as a result of that.