### PR TITLE
PP-2329 Specified Node.js engine version to 6.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 #node modules 
 node_modules/
+.idea

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "type": "git",
     "url": "https://github.com/alphagov/pay-admin-dashboard"
   },
+  "license": "MIT",
+  "engines": {
+    "node": "6.11.1"
+  },
   "author": "Christophe Kalista",
   "dependencies": {
     "babel-core": "~6.5.1",


### PR DESCRIPTION
Adds a specified Node.js engine to the configuration, as opposed to this being implicit. This is consistent with the rest of our applications that are used on Heroku.